### PR TITLE
Updated to require scikit-learn >= 1.1 for RocCurveDisplay.from_predi…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ scikeras~=0.9
 pandas~=1.3
 numpy~=1.21 ; python_version < '3.8'
 numpy~=1.22 ; python_version >= '3.8'
-scikit-learn~=1.0
+scikit-learn~=1.1
 seaborn~=0.12
 matplotlib~=3.5 ; python_version < '3.8'
 matplotlib~=3.6 ; python_version >= '3.8'


### PR DESCRIPTION
…ctions().